### PR TITLE
Manage auth routes

### DIFF
--- a/client/app/views/auth/login.html.erb
+++ b/client/app/views/auth/login.html.erb
@@ -57,7 +57,7 @@ body {
             <a href="#" class="float-right">Forgot Password?</a>
         </div>        
     </form>
-    <p class="text-light text-center" style="color=#fafafa">Didn't Have Account Yet? <a class="text-light" href="/auth/register">Register Here</a></p>
+    <p class="text-light text-center" style="color=#fafafa">Didn't Have Account Yet? <a class="text-light" href="/register">Register Here</a></p>
 </div>
 </body>
 </html>

--- a/client/app/views/auth/register.html.erb
+++ b/client/app/views/auth/register.html.erb
@@ -112,7 +112,7 @@ body {
             <button type="submit" class="btn btn-primary btn-lg">Sign Up</button>
         </div>
     </form>
-	<div class="text-center">Already have an account? <a href="/auth/login">Login here</a></div>
+	<div class="text-center">Already have an account? <a href="/login">Login here</a></div>
 </div>
 </body>
 </html>

--- a/client/config/routes.rb
+++ b/client/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
-  get 'auth/login'
-  get 'auth/register'
-  get 'auth/privacy'
-  get 'auth/terms'
+
+  root 'auth#login'
+
+  resources :users, only: [:login, :register]
+
+  get '/login', to: 'auth#login'
+  get '/register', to: 'auth#register'
+  get '/privacy', to: 'auth#privacy'
+  get '/terms', to: 'auth#terms'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
re-initialize `auth` routes to have aliases, so that it hide the full path of the `controller` file in browser address bar